### PR TITLE
Make sure assets exist for tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -106,8 +106,7 @@ upgrade env package="": virtualenv
 
 # *ARGS is variadic, 0 or more. This allows us to do `just test -k match`, for example.
 # Run the tests
-test *ARGS: devenv
-    $BIN/python manage.py collectstatic --no-input && \
+test *ARGS: assets
     $BIN/python -m pytest --cov=. --cov-report html --cov-report term-missing:skip-covered {{ ARGS }}
 
 


### PR DESCRIPTION
This will selectively run the asset building pipeline, including collectstatic, when running tests.