### PR TITLE
Update the setup-just GHA to v1.5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: "3.10"
           cache: pip
           cache-dependency-path: requirements.*.txt
-      - uses: extractions/setup-just@v1
+      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
       - name: Check formatting, linting and import sorting
         run: just check
 
@@ -62,7 +62,7 @@ jobs:
           python-version: "3.10"
           cache: pip
           cache-dependency-path: requirements.*.txt
-      - uses: extractions/setup-just@v1
+      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
 
       - name: Retrieve assets
         uses: actions/download-artifact@v3
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb  # v1.4.0
+      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
 
       - name: Build docker image and run tests in it
         run: |
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb  # v1.4.0
+      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
 
       - name: Build docker image
         run: |


### PR DESCRIPTION
GitHub are warning that they've deprecated actions running the version of node used by v1.4.0, so this update the setup-just action to the latest version.

Pinned to the exact version as this is a third-party action.