### PR TITLE
look up MEDIA_ROOT from the env with a fallback

### DIFF
--- a/reports/settings.py
+++ b/reports/settings.py
@@ -154,7 +154,7 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # User uploaded files
 # https://docs.djangoproject.com/en/4.1/topics/files/
-MEDIA_ROOT = BASE_DIR / "uploads"
+MEDIA_ROOT = Path(env.str("MEDIA_STORAGE", default="uploads"))
 MEDIA_URL = "/uploads/"
 
 


### PR DESCRIPTION
In production the old config was creating a directory in the container's filesystem, which was of course removed on the next deployment or app reboot.