### PR TITLE
Apply black to migrations

### DIFF
--- a/gateway/migrations/0001_initial.py
+++ b/gateway/migrations/0001_initial.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/gateway/migrations/0002_output.py
+++ b/gateway/migrations/0002_output.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("gateway", "0001_initial"),
     ]

--- a/gateway/migrations/0003_delete_output.py
+++ b/gateway/migrations/0003_delete_output.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("gateway", "0002_output"),
     ]

--- a/gateway/migrations/0004_alter_user_organisations.py
+++ b/gateway/migrations/0004_alter_user_organisations.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("gateway", "0003_delete_output"),
     ]

--- a/gateway/migrations/0005_remove_organisations.py
+++ b/gateway/migrations/0005_remove_organisations.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("gateway", "0004_alter_user_organisations"),
     ]

--- a/reports/migrations/0001_initial.py
+++ b/reports/migrations/0001_initial.py
@@ -7,7 +7,6 @@ import reports.models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/reports/migrations/0002_front_matter_fields.py
+++ b/reports/migrations/0002_front_matter_fields.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0001_initial"),
     ]

--- a/reports/migrations/0003_output_cache_token.py
+++ b/reports/migrations/0003_output_cache_token.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0002_front_matter_fields"),
     ]

--- a/reports/migrations/0004_output_use_git_blob.py
+++ b/reports/migrations/0004_output_use_git_blob.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0003_output_cache_token"),
     ]

--- a/reports/migrations/0005_category.py
+++ b/reports/migrations/0005_category.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0004_output_use_git_blob"),
     ]

--- a/reports/migrations/0006_datamigration_add_default_category.py
+++ b/reports/migrations/0006_datamigration_add_default_category.py
@@ -15,7 +15,6 @@ def add_default_category(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0005_category"),
     ]

--- a/reports/migrations/0007_make_output_category_non_nullable.py
+++ b/reports/migrations/0007_make_output_category_non_nullable.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0006_datamigration_add_default_category"),
     ]

--- a/reports/migrations/0008_output_ondelete_protection_help_text_and_plural_names.py
+++ b/reports/migrations/0008_output_ondelete_protection_help_text_and_plural_names.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0007_make_output_category_non_nullable"),
     ]

--- a/reports/migrations/0009_rename_output_report.py
+++ b/reports/migrations/0009_rename_output_report.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0008_output_ondelete_protection_help_text_and_plural_names"),
     ]

--- a/reports/migrations/0010_rename_ouput_html_file_path_report_html_file_path.py
+++ b/reports/migrations/0010_rename_ouput_html_file_path_report_html_file_path.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0009_rename_output_report"),
     ]

--- a/reports/migrations/0011_rename_help_texts_and_related_category_name.py
+++ b/reports/migrations/0011_rename_help_texts_and_related_category_name.py
@@ -7,7 +7,6 @@ import reports.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0010_rename_ouput_html_file_path_report_html_file_path"),
     ]

--- a/reports/migrations/0012_ordering_for_category_and_report.py
+++ b/reports/migrations/0012_ordering_for_category_and_report.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0011_rename_help_texts_and_related_category_name"),
     ]

--- a/reports/migrations/0013_report_is_draft.py
+++ b/reports/migrations/0013_report_is_draft.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0012_ordering_for_category_and_report"),
     ]

--- a/reports/migrations/0014_report_view_draft_permission.py
+++ b/reports/migrations/0014_report_view_draft_permission.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0013_report_is_draft"),
     ]

--- a/reports/migrations/0015_report_contact_email.py
+++ b/reports/migrations/0015_report_contact_email.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0014_report_view_draft_permission"),
     ]

--- a/reports/migrations/0016_populate_menu_name_from_title.py
+++ b/reports/migrations/0016_populate_menu_name_from_title.py
@@ -14,7 +14,6 @@ def populate_title_from_menu_name(apps, _):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0015_report_contact_email"),
     ]

--- a/reports/migrations/0017_make_report_description_non_nullable.py
+++ b/reports/migrations/0017_make_report_description_non_nullable.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0016_populate_menu_name_from_title"),
     ]

--- a/reports/migrations/0018_link.py
+++ b/reports/migrations/0018_link.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0017_make_report_description_non_nullable"),
     ]

--- a/reports/migrations/0019_link_verbose_name_report_publication_help_text.py
+++ b/reports/migrations/0019_link_verbose_name_report_publication_help_text.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0018_link"),
     ]

--- a/reports/migrations/0020_report_doi.py
+++ b/reports/migrations/0020_report_doi.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0019_link_verbose_name_report_publication_help_text"),
     ]

--- a/reports/migrations/0021_report_doi_verbose_name.py
+++ b/reports/migrations/0021_report_doi_verbose_name.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0020_report_doi"),
     ]

--- a/reports/migrations/0022_add_report_job_server_fields.py
+++ b/reports/migrations/0022_add_report_job_server_fields.py
@@ -6,7 +6,6 @@ import reports.models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0021_report_doi_verbose_name"),
     ]

--- a/reports/migrations/0023_alter_report_last_updated.py
+++ b/reports/migrations/0023_alter_report_last_updated.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0022_add_report_job_server_fields"),
     ]

--- a/reports/migrations/0024_add_org_model_and_link_to_reports.py
+++ b/reports/migrations/0024_add_org_model_and_link_to_reports.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0023_alter_report_last_updated"),
     ]

--- a/reports/migrations/0025_set_bennett_as_default_org.py
+++ b/reports/migrations/0025_set_bennett_as_default_org.py
@@ -22,7 +22,6 @@ def remove_bennett_org(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0024_add_org_model_and_link_to_reports"),
     ]

--- a/reports/migrations/0026_require_org_on_reports.py
+++ b/reports/migrations/0026_require_org_on_reports.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0025_set_bennett_as_default_org"),
     ]

--- a/reports/migrations/0027_add_report_is_external.py
+++ b/reports/migrations/0027_add_report_is_external.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0026_require_org_on_reports"),
     ]

--- a/reports/migrations/0028_remove_report_is_external.py
+++ b/reports/migrations/0028_remove_report_is_external.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0027_add_report_is_external"),
     ]

--- a/reports/migrations/0029_add_report_external_description.py
+++ b/reports/migrations/0029_add_report_external_description.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0028_remove_report_is_external"),
     ]

--- a/reports/migrations/0030_add_created_and_updated_fields.py
+++ b/reports/migrations/0030_add_created_and_updated_fields.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("reports", "0029_add_report_external_description"),

--- a/reports/migrations/0031_get_audit_details_from_admin_log_entries.py
+++ b/reports/migrations/0031_get_audit_details_from_admin_log_entries.py
@@ -60,7 +60,6 @@ def remove_audit_data_from_reports(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0030_add_created_and_updated_fields"),
     ]

--- a/reports/migrations/0032_require_created_and_updated_fields.py
+++ b/reports/migrations/0032_require_created_and_updated_fields.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("reports", "0031_get_audit_details_from_admin_log_entries"),

--- a/reports/migrations/0033_update_links_verbose_plural.py
+++ b/reports/migrations/0033_update_links_verbose_plural.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0032_require_created_and_updated_fields"),
     ]

--- a/reports/migrations/0034_default_is_draft_to_true.py
+++ b/reports/migrations/0034_default_is_draft_to_true.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("reports", "0033_update_links_verbose_plural"),
     ]


### PR DESCRIPTION
This repo wasn't configured to require the check job in CI was green before merging, so dependabot PRs have been merging since ~Feb 2023 with these files failing.  That's been fixed in the repo config.

These changes come from black 23.x removing blank lines at the start of classes.