### PR TITLE
feat: change docker user from root to reports

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -150,6 +150,12 @@ LABEL org.opencontainers.image.created=$BUILD_DATE
 ARG GITREF=unknown
 LABEL org.opencontainers.image.revision=$GITREF
 
+# 10001 is jobrunner (used by job-server on the opensafely dokku server).
+# Although this runs on the bennett dokku server, choose 10002 to avoid
+# accidents in the future.
+ARG USERID=10002
+ARG GROUPID=10002
+USER ${USERID}:${GROUPID}
 
 ##################################################
 #
@@ -169,3 +175,8 @@ RUN --mount=type=cache,target=/root/.cache \
 
 # Override ENTRYPOINT rather than CMD so we can pass arbitrary commands to the entrypoint script
 ENTRYPOINT ["/app/docker/entrypoints/dev.sh"]
+
+# Run as non root user. Required when building image.
+ARG USERID
+ARG GROUPID
+USER ${USERID}:${GROUPID}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -44,6 +44,10 @@ services:
     build:
       # the dev stage in the Dockerfile
       target: reports-dev
+      args:
+        # user developer uid:gid in dev
+        - USERID=${DEV_USERID:-1000}
+        - GROUPID=${DEV_GROUPID:-1000}
     # paths relative to docker-compose.yaml file
     env_file:
       - ../.env

--- a/docker/justfile
+++ b/docker/justfile
@@ -1,5 +1,5 @@
-export DOCKER_USERID := `id -u`
-export DOCKER_GROUPID := `id -g`
+export DEV_USERID := `id -u`
+export DEV_GROUPID := `id -g`
 
 # Load .env files by default
 set dotenv-load := true


### PR DESCRIPTION
* this is based on the job-server process, but has no postgresql database, and no staticfile mount, so I think it doesn't require the same dev-base structure & some other bits