### PR TITLE
Stop caching report file to JobServerReport instances

### DIFF
--- a/reports/job_server.py
+++ b/reports/job_server.py
@@ -78,7 +78,6 @@ class JobServerReport:
     def __init__(self, report, use_cache=True):
         self.client = JobServerClient(use_cache=use_cache)
         self.report = report
-        self._fetched_html = None
 
     def clear_cache(self):
         """Clear the cache for the Report's job-server URL"""
@@ -93,20 +92,16 @@ class JobServerReport:
         Fetches a report html file (an exported jupyter notebook) from a
         job-server output URL based on `report`, a Report model instance.
         """
-        if self._fetched_html is not None:
-            return self._fetched_html
+        content, last_updated = self.client.get_file(self.report.job_server_url)
 
-        file, last_updated = self.client.get_file(self.report.job_server_url)
-
-        # convert to a date for Report.last_updated
+        # update Report.last_updated (a datetime.date) if the file on
+        # job-server has been updated
         job_server_last_updated = last_updated.date()
         if self.report.last_updated != job_server_last_updated:
             self.report.last_updated = job_server_last_updated
             self.report.save()
 
-        self._fetched_html = file
-
-        return self._fetched_html
+        return content
 
     @property
     def is_published(self):


### PR DESCRIPTION
This third layer of caching isn't possible to cache-bust.  Since we already have two other layers in actions, requests-cache and Django's cache in the templates, this layer doesn't appear to give us very much.

I'm unsure this will fix the problem listed in #550 but it's blocking me from testing any further.  I've traced the code through and been testing in a shell on production like so:
```python
# start at the bottom, with caching, mirroring production
"â\x80\x9c" in JobServerClient(use_cache=True).get_file(report.job_server_url)  # False

# layer 2, with caching, mirroring how the view and template would get the content
"â\x80\x9c" in JobServerReport(report, use_cache=True).get_html()  # True

# layer 3, with caching, mirroring how the templates call the render_html tag
remote = JobServerReport(report, use_cache=True)
"â\x80\x9c" in render_html(remote)  # True

# relevant code called from inside JobServerReport's get_html
"â\x80\x9c" in remote.client.get_file(report.job_server_url)  # False
```

Even manually setting `remote._fetched_html = None` doesn't seem to clear the problem, but since this level of caching shouldn't be giving us anything, the simplification should let me further unpick this.

Ref: #550 