### PR TITLE
Only add a trailing slash for non-API job-server URLs

### DIFF
--- a/reports/models.py
+++ b/reports/models.py
@@ -321,12 +321,15 @@ class Report(models.Model):
 
         # confirm the file exists at the given location
         if not empty_job_server_url:
-            # ensure job-server URLs end in a slash.  We're following redirects
-            # inside JobServerClient.get_file(), and requests-cache keys the
-            # responses it caches to the URL used in the final request.
-            # job-server is configured to redirect to URLs with a trailing
-            # slash, so lets ensure we always use those.
-            if not self.job_server_url.endswith("/"):
+            # ensure job-server URLs for published files end in a slash.  We're
+            # following redirects inside JobServerClient.get_file(), and
+            # requests-cache keys the responses it caches to the URL used in
+            # the final request.  job-server is configured to redirect to URLs
+            # with a trailing slash outside of it's API so lets ensure we
+            # always use those.
+            if "published" in self.job_server_url and not self.job_server_url.endswith(
+                "/"
+            ):
                 self.job_server_url += "/"
 
             job_server_report = JobServerReport(self, use_cache=False)

--- a/tests/reports/test_models.py
+++ b/tests/reports/test_models.py
@@ -262,6 +262,57 @@ def test_report_with_unpublished_output_and_published(bennett_org, httpretty):
         )
 
 
+@pytest.mark.django_db
+def test_report_with_published_job_server_url_adds_trailing_slash(
+    bennett_org, httpretty
+):
+    httpretty.register_uri(
+        httpretty.HEAD, "http://example.com/published/foo", status=200
+    )
+    httpretty.register_uri(
+        httpretty.HEAD, "http://example.com/published/foo/", status=200
+    )
+
+    report = ReportFactory(
+        org=bennett_org,
+        is_draft=False,
+        repo="",
+        branch="",
+        report_html_file_path="",
+        job_server_url="http://example.com/published/foo",
+    )
+    assert report.job_server_url.endswith("/")
+
+    report = ReportFactory(
+        org=bennett_org,
+        is_draft=False,
+        repo="",
+        branch="",
+        report_html_file_path="",
+        job_server_url="http://example.com/published/foo/",
+    )
+    assert report.job_server_url.endswith("/")
+
+
+@pytest.mark.django_db
+def test_report_with_unpublished_job_server_url_does_not_add_trailing_slash(
+    bennett_org, httpretty
+):
+    httpretty.register_uri(
+        httpretty.HEAD, "http://example.com/api/v2/releases/file/foo", status=200
+    )
+
+    report = ReportFactory(
+        org=bennett_org,
+        is_draft=True,
+        repo="",
+        branch="",
+        report_html_file_path="",
+        job_server_url="http://example.com/api/v2/releases/file/foo",
+    )
+    assert not report.job_server_url.endswith("/")
+
+
 @pytest.mark.parametrize(
     "update_fields,cache_token_changed",
     [


### PR DESCRIPTION
Unpublished files are served via the API, which neither serves with a trailing slash nor redirects there.  So for draft reports we need to support that.