### PR TITLE
Update artifact actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v1.6.0
 
       - name: Retrieve assets
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: node-assets
           path: assets/dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm run build
 
       - name: Store assets
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: node-assets
           path: assets/dist


### PR DESCRIPTION
Replaces #575 and #576, which don't pass CI: both actions need to be updated at once.