### PR TITLE
Update SRO Measures info in `populate_reports.py`

### DIFF
--- a/reports/management/commands/populate_reports.py
+++ b/reports/management/commands/populate_reports.py
@@ -49,19 +49,8 @@ class Command(BaseCommand):
                 title="SRO Measures",
                 description="Changes in key GP measures during the COVID-19 pandemic",
                 repo="SRO-Measures",
-                branch="master",
-                report_html_file_path="released_outputs/output/sentinel_measures.html",
-            )
-
-            self.ensure_report(
-                category,
-                bennett,
-                user,
-                title="SRO Measures - Health Inequalities",
-                description="Changes in key GP measures during the pandemic - health inequalities",
-                repo="SRO-Measures",
-                branch="master",
-                report_html_file_path="released_outputs/output/sentinel_measures_demographics.html",
+                branch="main",
+                report_html_file_path="released_outputs/output/sentinel_measures_combined.html",
             )
 
     def ensure_report(self, category, org, user, **kwargs):


### PR DESCRIPTION
First, the repository had changed, making this code fail on trying to initialise a local database for development.

It appears that the reports were merged into one; see the following commits:

* opensafely/SRO-Measures@2f253a45e9e468e4e904f8c734790bb4555cd466
* opensafely/SRO-Measures@2270f7a4333e49a1734e213b0c35d2c2afbbf9be

Second, the current active branch seems to be `main`, although there's currently an old `master` branch there too.