### PR TITLE
Update tool versions in `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,12 @@ default_language_version:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.1.1
     hooks:
     - id: black
 
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 7.0.0
     hooks:
     - id: flake8
       additional_dependencies:
@@ -17,7 +17,7 @@ repos:
       - "flake8-implicit-str-concat"
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
     - id: isort
 


### PR DESCRIPTION
These were missed in previous upgrades.

The current repo-template eschews this approach for using local checks. We should switch to this.

In the meantime, at least make these consistent to avoid any confusion.