### PR TITLE
Use `opensafely-core/setup-action`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,12 +42,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: "actions/setup-python@v5"
+      - uses: "opensafely-core/setup-action@v1"
         with:
           python-version: "3.10"
-          cache: pip
           cache-dependency-path: requirements.*.txt
-      - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v1.6.0
+          install-just: true
       - name: Check formatting, linting and import sorting
         run: just check
 
@@ -57,12 +56,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: "actions/setup-python@v5"
+      - uses: "opensafely-core/setup-action@v1"
         with:
           python-version: "3.10"
-          cache: pip
           cache-dependency-path: requirements.*.txt
-      - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v1.6.0
+          install-just: true
 
       - name: Retrieve assets
         uses: actions/download-artifact@v4
@@ -95,7 +93,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v1.6.0
+      - uses: "opensafely-core/setup-action@v1"
+        with:
+          install-just: true
 
       - name: Build docker image and run tests in it
         run: |
@@ -117,7 +117,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d # v1.6.0
+      - uses: "opensafely-core/setup-action@v1"
+        with:
+          install-just: true
 
       - name: Build docker image
         run: |


### PR DESCRIPTION
To replace the third-party action for installing `just`.

Fixes #627.