### PR TITLE
Add `STORAGES["default"]`

### DIFF
--- a/reports/settings.py
+++ b/reports/settings.py
@@ -168,6 +168,9 @@ WHITENOISE_IMMUTABLE_FILE_TEST = immutable_file_test
 
 # Insert Whitenoise Middleware.
 STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
     "staticfiles": {
         "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
     },


### PR DESCRIPTION
04a61e6e replaced `STATICFILES_STORAGE` with `STORAGES["staticfiles"]`. The default value for `STORAGES` isn't merged with the user-supplied value ([1][]), so we should also add `STORAGES["default"]`.

[1]: https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-STORAGES

Fixes #645