### PR TITLE
Update Permissions-Policy to disable Topics

### DIFF
--- a/reports/settings.py
+++ b/reports/settings.py
@@ -235,4 +235,7 @@ if ASSETS_DEV_MODE:
 # https://github.com/adamchainz/django-permissions-policy/blob/main/README.rst
 PERMISSIONS_POLICY = {
     "interest-cohort": [],
+    # The following disables Google's Topics. For more information, see:
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/browsing-topics
+    "browsing-topics": [],
 }


### PR DESCRIPTION
django-permissions-policy was added by #344 to disable Google's [Federated Learning of
Cohorts](https://privacysandbox.com/proposals/floc/) (FLoC). FLoC was replaced by [Topics](https://privacysandbox.com/proposals/topics/) in May 2023, so we update the Permissions-Policy header to disable Topics.