### PR TITLE
Update dependabot config for weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -26,3 +30,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 20

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    allow:
-      - dependency-type: "production"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "tomodwyer"
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Moving to grouped PRs created weekly, and automatically setting npm updates to have @tomodwyer as the reviewer.