### PR TITLE
Add project metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+OpenSAFELY Reports
+Copyright (C) University of Oxford
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
+[project]
+name = "reports"
+description = "reports"
+readme = "README.md"
+authors = [{name = "OpenSAFELY", email = "tech@opensafely.org"}]
+license = {file = "LICENSE"}
+classifiers = [
+  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+]
+requires-python = ">=3.12"
+
 [tool.coverage.run]
 branch = true
 dynamic_context = "test_function"


### PR DESCRIPTION
This is very similar to opensafely-core/actions-registry#332, with the exception that we add (rather than update) `LICENSE`.

We add project metadata to `pyproject.toml` because:

1. This is how the Python community have agreed to store project
   metadata, for packaging as well as for other tools ([PEP 621][]).
2. Ruff looks to `project.requires-python` to determine which Python to
   use; if neither are provided, it defaults to Python 3.9 (#810). This
   project, however, uses Python 3.12. Not having this project metadata
   will, sooner or later, mean that some code will have to be
   reformatted.

[PEP 621]: https://peps.python.org/pep-0621/

