### PR TITLE
Remove Python distutils

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,7 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # use space efficient utility from base image
 RUN --mount=type=cache,target=/var/cache/apt \
     echo "deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu focal main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
-    /usr/lib/apt/apt-helper download-file 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776' /etc/apt/trusted.gpg.d/deadsnakes.asc &&\
-    root/docker-apt-install.sh python3.12 python3.12-venv python3.12-distutils tzdata ca-certificates
+    /usr/lib/apt/apt-helper download-file 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776' /etc/apt/trusted.gpg.d/deadsnakes.asc
 
 RUN ls usr/bin
 # install any additional system dependencies

--- a/docker/dependencies.txt
+++ b/docker/dependencies.txt
@@ -1,1 +1,5 @@
 # list ubuntu packages needed in production, one per line
+python3.12
+python3.12-venv
+tzdata
+ca-certificates


### PR DESCRIPTION
The distutils module has been deprecated for some time and was removed in Python3.12 [1]. A recent update to deadsnakes means that the package is no longer available at all and is breaking the build. Removing the package doesn't appear to break anything and it's likely that everything has already been moved over to setup tools.

[1] https://peps.python.org/pep-0632/#migration-advice