### PR TITLE
Update expected error message from GitHub

### DIFF
--- a/tests/reports/test_models.py
+++ b/tests/reports/test_models.py
@@ -34,7 +34,7 @@ REAL_REPO_DETAILS = {
         (
             {"report_html_file_path": "dummy-reports/report.html"},
             False,
-            "Error fetching report file: Not Found",
+            "Error fetching report file: No object found for the path dummy-reports",
         ),
         (
             {"branch": "non-existent-branch"},


### PR DESCRIPTION
It appears that GitHub's API has been updated to give a more informative error message, so this change updates the corresponding test.