### PR TITLE
Pin django-csp to <4.0

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -4,7 +4,7 @@
 # pip-compile --generate-hashes --output-file=requirements.prod.txt requirements.prod.in
 bs4
 django
-django-csp
+django-csp<4.0
 django-extensions
 django-permissions-policy
 django-structlog


### PR DESCRIPTION
django-csp 4.0 contains a number of breaking changes and requires a manual migration of settings to work correctly:
https://django-csp.readthedocs.io/en/latest/migration-guide.html

This commit pins the version to less than 4.0 to avoid dependabot noise until such time as we manually upgrade it and migrate the settings.