### PR TITLE
Update django-csp to v4

### DIFF
--- a/reports/settings.py
+++ b/reports/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 import re
 from pathlib import Path
 
+from csp.constants import NONE, SELF, UNSAFE_INLINE
 from django.urls import reverse_lazy
 from environs import Env
 from furl import furl
@@ -211,24 +212,33 @@ CACHES = {
 
 # CSP
 # https://django-csp.readthedocs.io/en/latest/configuration.html
-CSP_REPORT_ONLY = DEBUG
-CSP_DEFAULT_SRC = ["'none'"]
-
-# Duplicate the *_ELEM settings for Firefox
-# https://bugzilla.mozilla.org/show_bug.cgi?id=1529338
-CSP_STYLE_SRC = CSP_STYLE_SRC_ELEM = ["'self'", "https://fonts.googleapis.com"]
-CSP_SCRIPT_SRC = CSP_SCRIPT_SRC_ELEM = ["'self'", "https://plausible.io"]
-
-CSP_CONNECT_SRC = ["https://plausible.io"]
-CSP_FONT_SRC = ["'self'", "https://fonts.gstatic.com"]
-CSP_IMG_SRC = ["'self'", "data:"]
-CSP_MANIFEST_SRC = ["'self'"]
+CONNECT_SRC = ["https://plausible.io"]
+FONT_SRC = [SELF, "https://fonts.gstatic.com"]
+SCRIPT_SRC = [SELF, "https://plausible.io"]
+STYLE_SRC = [SELF, "https://fonts.googleapis.com"]
 
 # configure django-csp to work with Vite when using it in dev mode
 if ASSETS_DEV_MODE:
-    CSP_CONNECT_SRC = ["ws://localhost:5173/static/"]
-    CSP_SCRIPT_SRC_ELEM = ["'self'", "http://localhost:5173"]
-    CSP_STYLE_SRC_ELEM = ["'self'", "https://fonts.googleapis.com", "'unsafe-inline'"]
+    CONNECT_SRC = SCRIPT_SRC + ["ws://localhost:5173/static/"]
+    SCRIPT_SRC = SCRIPT_SRC + ["http://localhost:5173"]
+    STYLE_SRC = STYLE_SRC + [UNSAFE_INLINE]
+
+CONTENT_SECURITY_POLICY = {
+    "EXCLUDE_URL_PREFIXES": ["/api"],
+    "DIRECTIVES": {
+        "connect-src": CONNECT_SRC,
+        "default-src": [NONE],
+        "font-src": FONT_SRC,
+        "img-src": [SELF, "data:"],
+        "manifest-src": [SELF],
+        "script-src": SCRIPT_SRC,
+        "style-src": STYLE_SRC,
+        # Duplicate the *_ELEM settings for Firefox
+        # https://bugzilla.mozilla.org/show_bug.cgi?id=1529338
+        "script-src-elem": SCRIPT_SRC,
+        "style-src-elem": STYLE_SRC,
+    },
+}
 
 
 # Permissions Policy

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -4,7 +4,7 @@
 # pip-compile --generate-hashes --output-file=requirements.prod.txt requirements.prod.in
 bs4
 django
-django-csp<4.0
+django-csp
 django-extensions
 django-permissions-policy
 django-structlog

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -146,9 +146,9 @@ django-cache-url==3.3.0 \
     --hash=sha256:888c6954fdb3c7223e771b61528d7f7dc5987965cd93a6881b9bb31f0ef6d394 \
     --hash=sha256:dd689515d78a824f469d9cd4e447198999d2f13d1279487da20203f2f3b1e06b
     # via environs
-django-csp==3.8 \
-    --hash=sha256:19b2978b03fcd73517d7d67acbc04fbbcaec0facc3e83baa502965892d1e0719 \
-    --hash=sha256:ef0f1a9f7d8da68ae6e169c02e9ac661c0ecf04db70e0d1d85640512a68471c0
+django-csp==4.0 \
+    --hash=sha256:b27010bb702eb20a3dad329178df2b61a2b82d338b70fbdc13c3a3bd28712833 \
+    --hash=sha256:d5a0a05463a6b75a4f1fc1828c58c89af8db9364d09fc6e12f122b4d7f3d00dc
     # via -r requirements.prod.in
 django-extensions==4.1 \
     --hash=sha256:0699a7af28f2523bf8db309a80278519362cd4b6e1fd0a8cd4bf063e1e023336 \
@@ -325,6 +325,7 @@ packaging==23.1 \
     --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61 \
     --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f
     # via
+    #   django-csp
     #   gunicorn
     #   marshmallow
 platformdirs==4.2.0 \


### PR DESCRIPTION
Closes #942 

Update the config and dependency so that we can use django-csp v4.

[Migration guide](https://django-csp.readthedocs.io/en/v4.0/migration-guide.html)