### PR TITLE
Unpin `pip`

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ virtualenv:
     PYTHON_VERSION=${PYTHON_VERSION:-python3.12}
 
     # create venv and upgrade pip
-    test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install pip==25.0.1; }
+    test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install pip --upgrade; }
 
     # ensure we have pip-tools so we can run pip-compile
     test -e $BIN/pip-compile || $PIP install pip-tools

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -14,6 +14,3 @@ pytest-env
 pytest-freezer
 pytest-mock
 ruff
-# Pin pip due to incompatibility of later releases with pip-tools
-# https://github.com/jazzband/pip-tools/issues/2176
-pip==25.2


### PR DESCRIPTION
This was required due to an incompatibility of `pip-tools` with newer `pip` versions.

[That issue](https://github.com/jazzband/pip-tools/issues/2176) is now fixed, and we can upgrade again.